### PR TITLE
Implement useful fallback method for colVars()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,5 @@ URL: https://github.com/Bioconductor/MatrixGenerics
 BugReports: https://github.com/Bioconductor/MatrixGenerics/issues
 RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE, old_usage = TRUE)
-Suggests: 
-    testthat (>= 2.1.0)
+Suggests: sparseMatrixStats, DelayedMatrixStats, testthat (>= 2.1.0)
 biocViews: Infrastructure, Software

--- a/R/rowVars.R
+++ b/R/rowVars.R
@@ -1,3 +1,65 @@
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### load_next_suggested_package_to_search()
+###
+### The purpose of load_next_suggested_package_to_search() is to support
+### useful fallbacks methods i.e. "ANY" methods that implement a fallback
+### mechanism in case dispatch failed to find a suitable method.
+### Only used for the colVars() generic for now, as a proof of concept. See
+### colVars#ANY method below.
+### This file is a temporary place for load_next_suggested_package_to_search().
+### If we decide to add this type of fallback methods for all the generics in
+### MatrixGenerics, load_next_suggested_package_to_search() would need to go
+### to its own .R file.
+
+### All packages listed below must also be listed in the Suggests field.
+### They are expected to implement methods for the generics defined in
+### MatrixGenerics. No need to list matrixStats here, MatrixGenerics already
+### imports it by default.
+.SUGGESTED_PACKAGES_TO_SEARCH <- c(
+    "sparseMatrixStats",
+    ## We list DelayedMatrixStats even though the methods defined in that
+    ## package won't be found by the generics in MatrixGenerics. This is
+    ## because DelayedMatrixStats defines its own matrixStats generics.
+    "DelayedMatrixStats"
+    #, ... add more packages in the future
+)
+
+.long_and_fancy_errmsg <- function(crude_errmsg, unloaded_pkgs)
+{
+    plural <- length(unloaded_pkgs) > 1L
+    errmsg <- paste0(crude_errmsg,  "\n  However, the following package",
+        if (plural) "s are" else " is",
+        " likely to contain the missing method\n  but ",
+        if (plural) "are" else "is", " not installed: ",
+        paste0(unloaded_pkgs, collapse=", "), "\n  ",
+        "Please install ", if (plural) "them" else "it",
+        " (with 'BiocManager::install()') and try again.")
+    if (plural)
+        errmsg <- paste0(errmsg, "\n  Alternatively, if you know where ",
+                         "the missing method is defined, install\n  only ",
+                         "that package.")
+    errmsg
+}
+
+### Try to load installed packages first.
+load_next_suggested_package_to_search <- function(GENERIC, x)
+{
+    crude_errmsg <- paste0("Failed to find a ", GENERIC," method for ",
+                           class(x), " objects.")
+    is_loaded <- vapply(.SUGGESTED_PACKAGES_TO_SEARCH, isNamespaceLoaded,
+                        logical(1))
+    if (all(is_loaded))
+        stop(crude_errmsg)
+    unloaded_pkgs <- .SUGGESTED_PACKAGES_TO_SEARCH[!is_loaded]
+    for (pkg in unloaded_pkgs) {
+        if (requireNamespace(pkg, quietly=TRUE))
+            return()
+    }
+    stop(.long_and_fancy_errmsg(crude_errmsg, unloaded_pkgs))
+}
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 #' Calculates the variance for each row (column) of a matrix-like object
 #'
 #' Calculates the variance for each row (column) of a matrix-like object.
@@ -71,5 +133,12 @@ setMethod("colVars", signature = "numeric", .default_colVars)
 #' @rdname rowVars
 setMethod("colVars", signature = "array", .default_colVars)
 
+#' @rdname rowVars
+setMethod("colVars", signature = "ANY",
+  function(x, rows = NULL, cols = NULL, na.rm = FALSE, center = NULL, dim. = dim(x), ...){
+    load_next_suggested_package_to_search("colVars()", x)
+    callGeneric()
+  }
+)
 
 

--- a/man/rowVars.Rd
+++ b/man/rowVars.Rd
@@ -9,6 +9,7 @@
 \alias{colVars,matrix-method}
 \alias{colVars,numeric-method}
 \alias{colVars,array-method}
+\alias{colVars,ANY-method}
 \title{Calculates the variance for each row (column) of a matrix-like object}
 \usage{
 rowVars(x, rows = NULL, cols = NULL, na.rm = FALSE, center = NULL, ...)


### PR DESCRIPTION
Hi @const-ae, @PeteHaitch, @LTLA, @lawremi, 

This improves a little bit upon my earlier proposal on the community-bioc slack this morning (bigdata-rep channel) of loading all the suggested packages the first time a **MatrixGenerics**' generic is called (e.g. the first time `MatrixGenerics::colVars()` is called). With this new approach, if I'm passing a dgCMatrix object and if **sparseMatrixStats** is already loaded, the fallback mechanism won't try to load anything. So this addresses Nicholas Knoblauch's concern that there is no reason to throw an error that **DelayedMatrixStats** is not installed in that case.

```
library(MatrixGenerics)
library(Matrix)
sm <- as(matrix(1:12, ncol=3), "sparseMatrix")
```

#### Without fallback mechanism:

```
rowVars(sm)
# Error in (function (classes, fdef, mtable)  : 
#   unable to find an inherited method for function ‘rowVars’ for signature ‘"dgCMatrix"’
```

#### With the fallback mechanism:

If **sparseMatrixStats** is installed, the fallback mechanism loads it so dispatch can find the method:
```
colVars(sm)
# [1] 1.666667 1.666667 1.666667
```

If **sparseMatrixStats** and "other suggested packages to search" (e.g. **DelayedMatrixstats**) are not installed we get:
```
colVars(sm)
# Error in load_next_suggested_package_to_search("colVars()", x) : 
#   Failed to find a colVars() method for dgCMatrix objects.
#   However, the following packages are likely to contain the missing method
#   but are not installed: sparseMatrixStats, DelayedMatrixStats
#   Please install them (with 'BiocManager::install()') and try again.
#   Alternatively, if you know where the missing method is defined, install
#   only that package.
```

If **sparseMatrixStats** is the only "other suggested packages to search" that is not installed we get:
```
colVars(sm)
# Error in load_next_suggested_package_to_search("colVars()", x) : 
#   Failed to find a colVars() method for dgCMatrix objects.
#   However, the following package is likely to contain the missing method
#   but is not installed: sparseMatrixStats
#   Please install it (with 'BiocManager::install()') and try again.
```

Note that this approach still doesn't guarantee that users will always have all the packages that define every possible methods for the **MatrixGenerics**' generics, so is complementary to Aaron's approach of using **beachmat** or **scuttle** as an umbrella package for the sc-stack that he controls. But at least it provides a reasonable safety net for packages that don't belong to this stack. They need to import **MatrixGenerics** only.

Open for discussion.

H.