### PR TITLE
Add drop and type to generic signature of [row|col]Quantiles

### DIFF
--- a/R/rowQuantiles.R
+++ b/R/rowQuantiles.R
@@ -16,12 +16,8 @@
 #' @param probs A numeric vector of J probabilities in \[0, 1\].
 #' @template na_rmParameter
 #' @param type An integer specifying the type of estimator. See 
-#'   \code{stats::\link[stats]{quantile}()}. for more details. Note, that this
-#'   is not a generic argument and not all implementation of this function have
-#'   to provide it.
+#'   \code{stats::\link[stats]{quantile}()}. for more details.
 #' @param drop If `TRUE` a vector is returned if `J == 1`.
-#'   Note, that this is not a generic argument and not all implementation of 
-#'   this function have to provide it.
 #' 
 #' @template returnMatrix_JDim
 #' 
@@ -36,7 +32,10 @@
 #' @template standardExamples
 #'
 #' @keywords array iteration robust
-setGeneric("rowQuantiles", function(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, ...) standardGeneric("rowQuantiles"),
+#'
+#' @name rowQuantiles
+#' @export
+setGeneric("rowQuantiles", function(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, type = 7L, ..., drop = TRUE) standardGeneric("rowQuantiles"),
            signature = "x"
 )
 
@@ -58,7 +57,7 @@ setMethod("rowQuantiles", "ANY", make_default_method_def("rowQuantiles"))
 
 #' @export
 #' @rdname rowQuantiles
-setGeneric("colQuantiles", function(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, ...) standardGeneric("colQuantiles"),
+setGeneric("colQuantiles", function(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, type = 7L, ..., drop = TRUE) standardGeneric("colQuantiles"),
            signature = "x"
 )
 

--- a/R/rowQuantiles.R
+++ b/R/rowQuantiles.R
@@ -32,9 +32,6 @@
 #' @template standardExamples
 #'
 #' @keywords array iteration robust
-#'
-#' @name rowQuantiles
-#' @export
 setGeneric("rowQuantiles", function(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, type = 7L, ..., drop = TRUE) standardGeneric("rowQuantiles"),
            signature = "x"
 )

--- a/man/rowQuantiles.Rd
+++ b/man/rowQuantiles.Rd
@@ -10,24 +10,26 @@
 \title{Calculates quantiles for each row (column) of a matrix-like object}
 \usage{
 rowQuantiles(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1,
-  by = 0.25), na.rm = FALSE, ...)
+  by = 0.25), na.rm = FALSE, type = 7L, ..., drop = TRUE)
 
 \S4method{rowQuantiles}{matrix_OR_array_OR_table_OR_numeric}(x, rows = NULL,
   cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE,
   type = 7L, ..., drop = TRUE)
 
 \S4method{rowQuantiles}{ANY}(x, rows = NULL, cols = NULL,
-  probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, ...)
+  probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, type = 7L,
+  ..., drop = TRUE)
 
 colQuantiles(x, rows = NULL, cols = NULL, probs = seq(from = 0, to = 1,
-  by = 0.25), na.rm = FALSE, ...)
+  by = 0.25), na.rm = FALSE, type = 7L, ..., drop = TRUE)
 
 \S4method{colQuantiles}{matrix_OR_array_OR_table_OR_numeric}(x, rows = NULL,
   cols = NULL, probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE,
   type = 7L, ..., drop = TRUE)
 
 \S4method{colQuantiles}{ANY}(x, rows = NULL, cols = NULL,
-  probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, ...)
+  probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE, type = 7L,
+  ..., drop = TRUE)
 }
 \arguments{
 \item{x}{An NxK matrix-like object.}
@@ -41,16 +43,12 @@ done.}
 \item{na.rm}{If \code{\link[base:logical]{TRUE}}, \code{\link{NA}}s
 are excluded first, otherwise not.}
 
+\item{type}{An integer specifying the type of estimator. See
+\code{stats::\link[stats]{quantile}()}. for more details.}
+
 \item{...}{Additional arguments passed to specific methods.}
 
-\item{type}{An integer specifying the type of estimator. See
-\code{stats::\link[stats]{quantile}()}. for more details. Note, that this
-is not a generic argument and not all implementation of this function have
-to provide it.}
-
-\item{drop}{If \code{TRUE} a vector is returned if \code{J == 1}.
-Note, that this is not a generic argument and not all implementation of
-this function have to provide it.}
+\item{drop}{If \code{TRUE} a vector is returned if \code{J == 1}.}
 }
 \value{
 a \code{\link{numeric}} \code{NxJ} (\code{KxJ})


### PR DESCRIPTION
After some discussion with @LTLA in https://github.com/const-ae/sparseMatrixStats/issues/7, I decided that it is probably a good idea to include `drop` and `type` (which `sparseMatrixStats` now fully supports) in the generic method signature.

What do you think?