### PR TITLE
Remove scalar center arguments in test-api_compatibility

### DIFF
--- a/tests/testthat/generate_tests_helper_script.R
+++ b/tests/testthat/generate_tests_helper_script.R
@@ -127,6 +127,8 @@ res <- paste0(sapply(testable_functions, function(fnc_name){
   } else if (fnc_name == "rowAvgsPerColSet") {
     filled_in_args[["FUN"]] <- filled_in_args[["FUN"]][
       sapply(filled_in_args[["FUN"]], function(x) grepl("^row", x))]
+  } else if(fnc_name == "colWeightedMads" || fnc_name == "rowWeightedMads") {
+    filled_in_args[[paste0(substr(fnc_name, 1, 3), "_center")]][[2]] <- 6
   }
   filled_in_args_str <- lapply(seq_along(arg_names), function(idx) paste0(arg_names[idx], " = ", filled_in_args[[idx]]))
   param_tests <- paste0(sapply(seq_len(max(lengths(filled_in_args_str))), function(idx){

--- a/tests/testthat/generate_tests_helper_script.R
+++ b/tests/testthat/generate_tests_helper_script.R
@@ -40,7 +40,8 @@ function_args <- list(x = list("mat"),
                       diff = list(1, 2),
                       trim = list(0, 1/3, 0.5),
                       lx = list("mat"),
-                      center = list(NULL, 3.1),
+                      col_center = list("NULL", "rep(0.3, ncol(mat))"),
+                      row_center = list("NULL", "rep(0.3, nrow(mat))"),
                       constant = list(1.4826, 5),
                       which = list(2, 1),
                       method = list("'direct'", "'expSumLog'"),
@@ -115,7 +116,9 @@ res <- paste0(sapply(testable_functions, function(fnc_name){
   
   # Now all combinations of parameters
   arg_names <- setdiff(names(default_args), "...")
-  filled_in_args <- function_args[arg_names]
+  arg_names_lookup <- arg_names
+  arg_names_lookup[arg_names_lookup == "center"] <- paste0(substr(fnc_name, 1, 3), "_center")
+  filled_in_args <- function_args[arg_names_lookup]
   # Need special handling of colAvgsPerRowSet / rowAvgsPerColSet
   if (fnc_name == "colAvgsPerRowSet") {
     filled_in_args[["cols"]][[2]] <- 1:2

--- a/tests/testthat/test-api_compatibility.R
+++ b/tests/testthat/test-api_compatibility.R
@@ -357,8 +357,8 @@ test_that("colMads works ", {
 	ms_res_1 <- matrixStats::colMads(x = mat, rows = NULL, cols = NULL, center = NULL, constant = 1.4826, na.rm = TRUE, dim. = dim(mat))
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- colMads(x = mat, rows = 1:3, cols = 2, center = 3.1, constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
-	ms_res_2 <- matrixStats::colMads(x = mat, rows = 1:3, cols = 2, center = 3.1, constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
+	mg_res_2 <- colMads(x = mat, rows = 1:3, cols = 2, center = rep(0.3, ncol(mat)), constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
+	ms_res_2 <- matrixStats::colMads(x = mat, rows = 1:3, cols = 2, center = rep(0.3, ncol(mat)), constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -590,8 +590,8 @@ test_that("colSds works ", {
 	ms_res_1 <- matrixStats::colSds(x = mat, rows = NULL, cols = NULL, na.rm = TRUE, center = NULL, dim. = dim(mat))
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- colSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
-	ms_res_2 <- matrixStats::colSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
+	mg_res_2 <- colSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, ncol(mat)), dim. = c(12L, 8L))
+	ms_res_2 <- matrixStats::colSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, ncol(mat)), dim. = c(12L, 8L))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -675,8 +675,8 @@ test_that("colVars works ", {
 	ms_res_1 <- matrixStats::colVars(x = mat, rows = NULL, cols = NULL, na.rm = TRUE, center = NULL, dim. = dim(mat))
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- colVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
-	ms_res_2 <- matrixStats::colVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
+	mg_res_2 <- colVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, ncol(mat)), dim. = c(12L, 8L))
+	ms_res_2 <- matrixStats::colVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, ncol(mat)), dim. = c(12L, 8L))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -695,8 +695,8 @@ test_that("colWeightedMads works ", {
 	ms_res_1 <- matrixStats::colWeightedMads(x = mat, w = 1:16, rows = NULL, cols = NULL, na.rm = TRUE, constant = 1.4826, center = NULL)
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 3.1)
-	ms_res_2 <- matrixStats::colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 3.1)
+	mg_res_2 <- colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, ncol(mat)))
+	ms_res_2 <- matrixStats::colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, ncol(mat)))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -1124,8 +1124,8 @@ test_that("rowMads works ", {
 	ms_res_1 <- matrixStats::rowMads(x = mat, rows = NULL, cols = NULL, center = NULL, constant = 1.4826, na.rm = TRUE, dim. = dim(mat))
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- rowMads(x = mat, rows = 1:3, cols = 2, center = 3.1, constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
-	ms_res_2 <- matrixStats::rowMads(x = mat, rows = 1:3, cols = 2, center = 3.1, constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
+	mg_res_2 <- rowMads(x = mat, rows = 1:3, cols = 2, center = rep(0.3, nrow(mat)), constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
+	ms_res_2 <- matrixStats::rowMads(x = mat, rows = 1:3, cols = 2, center = rep(0.3, nrow(mat)), constant = 5, na.rm = FALSE, dim. = c(12L, 8L))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -1357,8 +1357,8 @@ test_that("rowSds works ", {
 	ms_res_1 <- matrixStats::rowSds(x = mat, rows = NULL, cols = NULL, na.rm = TRUE, center = NULL, dim. = dim(mat))
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- rowSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
-	ms_res_2 <- matrixStats::rowSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
+	mg_res_2 <- rowSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, nrow(mat)), dim. = c(12L, 8L))
+	ms_res_2 <- matrixStats::rowSds(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, nrow(mat)), dim. = c(12L, 8L))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -1442,8 +1442,8 @@ test_that("rowVars works ", {
 	ms_res_1 <- matrixStats::rowVars(x = mat, rows = NULL, cols = NULL, na.rm = TRUE, center = NULL, dim. = dim(mat))
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- rowVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
-	ms_res_2 <- matrixStats::rowVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = 3.1, dim. = c(12L, 8L))
+	mg_res_2 <- rowVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, nrow(mat)), dim. = c(12L, 8L))
+	ms_res_2 <- matrixStats::rowVars(x = mat, rows = 1:3, cols = 2, na.rm = FALSE, center = rep(0.3, nrow(mat)), dim. = c(12L, 8L))
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -1463,8 +1463,8 @@ test_that("rowWeightedMads works ", {
 	ms_res_1 <- matrixStats::rowWeightedMads(x = mat, w = 1:16, rows = NULL, cols = NULL, na.rm = TRUE, constant = 1.4826, center = NULL)
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 3.1)
-	ms_res_2 <- matrixStats::rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 3.1)
+	mg_res_2 <- rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, nrow(mat)))
+	ms_res_2 <- matrixStats::rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, nrow(mat)))
 	expect_equal(mg_res_2, ms_res_2)
 })
 

--- a/tests/testthat/test-api_compatibility.R
+++ b/tests/testthat/test-api_compatibility.R
@@ -695,8 +695,8 @@ test_that("colWeightedMads works ", {
 	ms_res_1 <- matrixStats::colWeightedMads(x = mat, w = 1:16, rows = NULL, cols = NULL, na.rm = TRUE, constant = 1.4826, center = NULL)
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, ncol(mat)))
-	ms_res_2 <- matrixStats::colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, ncol(mat)))
+	mg_res_2 <- colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 6)
+	ms_res_2 <- matrixStats::colWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 6)
 	expect_equal(mg_res_2, ms_res_2)
 })
 
@@ -1463,8 +1463,8 @@ test_that("rowWeightedMads works ", {
 	ms_res_1 <- matrixStats::rowWeightedMads(x = mat, w = 1:16, rows = NULL, cols = NULL, na.rm = TRUE, constant = 1.4826, center = NULL)
 	expect_equal(mg_res_1, ms_res_1)
 
-	mg_res_2 <- rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, nrow(mat)))
-	ms_res_2 <- matrixStats::rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = rep(0.3, nrow(mat)))
+	mg_res_2 <- rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 6)
+	ms_res_2 <- matrixStats::rowWeightedMads(x = mat, w = NULL, rows = 1:3, cols = 2, na.rm = FALSE, constant = 5, center = 6)
 	expect_equal(mg_res_2, ms_res_2)
 })
 


### PR DESCRIPTION
* This beginns to address #17 and is in response to
  https://github.com/HenrikBengtsson/matrixStats/issues/183
* The test still fails for colWeightedMads, but I think this is
should be fixed in matrixStats, because right now the handling of center
 between colWeightedMads and colMads is inconsistent