### PR TITLE
Use formals() instead of args() in make_default_method_def() to address issue #25

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: S4 generic functions modeled after the 'matrixStats' API
 biocViews: Infrastructure, Software
 URL: https://bioconductor.org/packages/MatrixGenerics
 BugReports: https://github.com/Bioconductor/MatrixGenerics/issues
-Version: 1.5.0
+Version: 1.5.1
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(person("Constantin", "Ahlmann-Eltze",

--- a/R/MatrixGenerics-package.R
+++ b/R/MatrixGenerics-package.R
@@ -106,7 +106,8 @@ setClassUnion("matrix_OR_array_OR_table_OR_numeric",
 
 make_default_method_def <- function(genericName)
 {
-    def <- args(match.fun(genericName))
+    def <- function() { }
+    formals(def) <- formals(match.fun(genericName))
     e <- expression(MatrixGenerics:::.load_next_suggested_package_to_search(x),
                     callGeneric())
     body(def) <- as.call(c(as.name("{"), e))

--- a/R/MatrixGenerics-package.R
+++ b/R/MatrixGenerics-package.R
@@ -111,6 +111,7 @@ make_default_method_def <- function(genericName)
     e <- expression(MatrixGenerics:::.load_next_suggested_package_to_search(x),
                     callGeneric())
     body(def) <- as.call(c(as.name("{"), e))
+    environment(def) <- getNamespace("MatrixGenerics")
     def
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,10 @@
 \title{News for Package \pkg{MatrixGenerics}}
 \encoding{UTF-8}
 
+\section{Version 1.5.1}{\itemize{
+  \item Fix problem with function environment of fallback mechanism (\url{https://github.com/Bioconductor/MatrixGenerics/issues/25} and \url{https://github.com/Bioconductor/MatrixGenerics/pull/26}). Make sure that packages can use MatrixGenerics with the \code{::} notation to call functions from \pkg{sparseMatrixStats} and \pkg{DelayedMatrixStats}.
+}}
+
 \section{Version 1.2.1}{\itemize{
   \item Sync API with \pkg{matrixStats} \code{v0.58.0}.
 }}


### PR DESCRIPTION
`args()` does not set the enclosing environment of the function correctly
(i.e., it uses the GlobalEnv) which leads to problems because `callGeneric()` and `match.fun()`  cannot find the function.

This should fix #25.