### PR TITLE
Fix #28

### DIFF
--- a/R/rowAvgsPerColSet.R
+++ b/R/rowAvgsPerColSet.R
@@ -70,7 +70,10 @@ setMethod("rowAvgsPerColSet", "matrix_OR_array_OR_table_OR_numeric", .matrixStat
 #' @export
 #' @rdname rowAvgsPerColSet
 ## Default method with user-friendly fallback mechanism.
-setMethod("rowAvgsPerColSet", "ANY", make_default_method_def("rowAvgsPerColSet"))
+setMethod("rowAvgsPerColSet", "ANY", function (X, W = NULL, rows = NULL, S, FUN = rowMeans, ..., na.rm = NA, tFUN = FALSE){
+  MatrixGenerics:::.load_next_suggested_package_to_search(X)
+  callGeneric()
+})
 
 
 
@@ -91,5 +94,8 @@ setMethod("colAvgsPerRowSet", "matrix_OR_array_OR_table_OR_numeric", .matrixStat
 #' @export
 #' @rdname rowAvgsPerColSet
 ## Default method with user-friendly fallback mechanism.
-setMethod("colAvgsPerRowSet", "ANY", make_default_method_def("colAvgsPerRowSet"))
+setMethod("colAvgsPerRowSet", "ANY", function (X, W = NULL, cols = NULL, S, FUN = colMeans, ..., na.rm = NA, tFUN = FALSE){
+  MatrixGenerics:::.load_next_suggested_package_to_search(X)
+  callGeneric()
+})
 

--- a/R/rowLogSumExps.R
+++ b/R/rowLogSumExps.R
@@ -50,7 +50,10 @@ setMethod("rowLogSumExps", "matrix_OR_array_OR_table_OR_numeric", .matrixStats_r
 #' @export
 #' @rdname rowLogSumExps
 ## Default method with user-friendly fallback mechanism.
-setMethod("rowLogSumExps", "ANY", make_default_method_def("rowLogSumExps"))
+setMethod("rowLogSumExps", "ANY", function (lx, rows = NULL, cols = NULL, na.rm = FALSE, ..., useNames = NA){
+  MatrixGenerics:::.load_next_suggested_package_to_search(lx)
+  callGeneric()
+})
 
 
 
@@ -71,5 +74,8 @@ setMethod("colLogSumExps", "matrix_OR_array_OR_table_OR_numeric", .matrixStats_c
 #' @export
 #' @rdname rowLogSumExps
 ## Default method with user-friendly fallback mechanism.
-setMethod("colLogSumExps", "ANY", make_default_method_def("colLogSumExps"))
+setMethod("colLogSumExps", "ANY", function (lx, rows = NULL, cols = NULL, na.rm = FALSE, ..., useNames = NA){
+  MatrixGenerics:::.load_next_suggested_package_to_search(lx)
+  callGeneric()
+})
 

--- a/tests/testthat/test-dynamic_implementation_loading.R
+++ b/tests/testthat/test-dynamic_implementation_loading.R
@@ -1,0 +1,20 @@
+
+
+test_that("sparse matrices trigger loading of sparseMatrixStats", {
+  library(Matrix)
+  # Make a matrix with different features
+  mat <- matrix(rnorm(16 * 6), nrow = 16, ncol = 6)
+  sp_mat <- as(mat, "dgCMatrix")
+  expect_equal(colLogSumExps(sp_mat), colLogSumExps(mat))
+})
+
+
+test_that("sparse matrices trigger loading of sparseMatrixStats", {
+  # Make a matrix with different features
+  mat <- matrix(rnorm(16 * 6), nrow = 16, ncol = 6)
+  sp_mat <- as(mat, "dgCMatrix")
+  expect_equal(colVars(sp_mat), colVars(mat))
+})
+
+
+


### PR DESCRIPTION
Unlike most other functions rowLogSumExps first argument is called `lx` instead of `x`. This caused `make_default_method_def("rowLogSumExps")` to generate erroneous code. To fix the issue I inline the correct code manually.